### PR TITLE
Adding loinc pipeline maven module

### DIFF
--- a/loinc-integration/pom.xml
+++ b/loinc-integration/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>dev.ikm.maven</groupId>
+            <groupId>dev.ikm.loinc</groupId>
             <artifactId>loinc-transformation-maven-plugin</artifactId>
             <version>1.0.0-SNAPSHOT</version>
             <scope>test</scope>

--- a/loinc-pipeline/pom.xml
+++ b/loinc-pipeline/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -9,13 +11,42 @@
 
     <groupId>dev.ikm.maven</groupId>
     <artifactId>loinc-pipeline</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <name>loinc-pipeline</name>
     <url>http://maven.apache.org</url>
 
     <properties>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>dev.ikm.loinc</groupId>
+                <artifactId>loinc-transformation-maven-plugin</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <configuration>
+                    <namespaceString>${origin.namespace}</namespaceString>
+                    <partCsv>${project.build.directory}/../../loinc-origin/target/origin-sources/AccessoryFiles/PartFile/Part.csv</partCsv>
+                    <loincCsv>${project.build.directory}/../../loinc-origin/target/origin-sources/LoincTable/Loinc.csv</loincCsv>
+                    <datastorePath>${user.home}/Solor/generated-data</datastorePath>
+                    <inputDirectoryPath>${user.home}/.m2/repository/dev/ikm/loinc/loinc-origin/${project.version}/loinc-origin-${project.version}-data.zip</inputDirectoryPath>
+                    <dataOutputPath>${project.build.directory}</dataOutputPath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>run-loinc-transformation</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run-loinc-transformation</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/plugin/loinc-transformation-maven-plugin/pom.xml
+++ b/plugin/loinc-transformation-maven-plugin/pom.xml
@@ -8,7 +8,8 @@
     </parent>
 
     <artifactId>loinc-transformation-maven-plugin</artifactId>
-    <packaging>pom</packaging>
+    <packaging>maven-plugin</packaging>
+    <version>1.0.0-SNAPSHOT</version>
 
     <name>loinc-transformation-maven-plugin</name>
     <url>http://maven.apache.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.tinkar</groupId>
         <artifactId>loinc-data-bom</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <relativePath/>
     </parent>
 
@@ -17,20 +17,19 @@
 
     <name>LOINC Data</name>
     <modules>
-        <module>loinc-origin</module>
         <module>plugin</module>
-        <module>loinc-pipeline</module>
+        <module>loinc-origin</module>
         <module>loinc-starterdata</module>
-<!--        <module>loinc-binding</module>-->
+        <module>loinc-binding</module>
 <!--        <module>loinc-pipeline</module>-->
 <!--        <module>loinc-owl-transform</module>-->
 <!--        <module>loinc-reasoner</module>-->
-<!--        <module>loinc-integration</module>-->
+        <module>loinc-integration</module>
     </modules>
 
     <properties>
         <!-- maven plugins -->
-        <maven-artifacts.version>1.14.0</maven-artifacts.version>
+        <maven-artifacts.version>1.16.0</maven-artifacts.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>


### PR DESCRIPTION
Code change fixes the mapping of the .csv files from LoincTransformationMojo to loinc-pipeline pom.xml module.
Note that code has <module>loinc-pipeline</module> commented in pom.xml (loinc-data), in order to build successfully the repo.

However, need to uncomment this line to see the future fixes to work in the following story/bug created: 
- IKDT-864 (Update LoincTransformationMojo to NOT take .csv files as parameters, but as Input Files)
- IKDT-865 (Fix Errors/Exceptions thrown from reading partCsv.csv and loincCsv.csv files)